### PR TITLE
chore: rename module path to github.com/techio-dev/caddy-storage-libsql

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/techio-dev/caddy-libsql-storage
+module github.com/techio-dev/caddy-storage-libsql
 
 go 1.24.2
 


### PR DESCRIPTION
Update the module path in go.mod to reflect the new repository
structure and naming convention. This change ensures consistency
with the project organization and improves clarity for users and
contributors.